### PR TITLE
Introduce directories for organization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,8 @@ class SayilarState extends State<Sayilar> {
         body: Center(
           child: TopicSelector(
             topics: [
+              // FIXME: These three topics should probably be moved into a
+              // "Numbers" DirectoryTopic once more exercises are added.
               const ExerciseTopic(
                 icon: Icons.visibility,
                 title: 'Recognize',

--- a/lib/widgets/topics/directory_topic.dart
+++ b/lib/widgets/topics/directory_topic.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'package:sayilar/widgets/topic_selector.dart';
+import 'package:sayilar/widgets/topics/topic.dart';
+
+/// A [Topic] for encapsulating and presenting other [Topic]s.
+class DirectoryTopic extends Topic {
+  /// Create a new [DirectoryTopic].
+  ///
+  /// This can be supplied with either a simple list of [topics], or with a list
+  /// of [topicGroups], where each sublist constitutes a grouping of the topics
+  /// within it. When topics are supplied in groups, each group will be visually
+  /// separated from the other groups. See [TopicSelector] for more information.
+  const DirectoryTopic({
+    super.icon,
+    required super.title,
+    super.subtitle,
+    this.topics,
+    this.topicGroups,
+  }) : assert(
+          (topics != null) ^ (topicGroups != null),
+          'Either `topics` or `topicGroups` must be given, not both.',
+        );
+
+  /// All of the selectable [Topic]s, not divided into groups.
+  final List<Topic>? topics;
+
+  /// All of the selectable [Topic]s, possibly divided into groups.
+  final List<List<Topic>>? topicGroups;
+
+  @override
+  Widget buildBody(BuildContext context) {
+    return TopicSelector(
+      topics: topics,
+      topicGroups: topicGroups,
+    );
+  }
+}


### PR DESCRIPTION
Add a `DirectoryTopic`, that bundles a list of other topics and moves them onto a separate page.
Right now this is not used, as there are still not too many topics on the front page, but e.g. when exercises for telling time are introduced in #24, this will come in handy.