### PR TITLE
Improve random selection

### DIFF
--- a/lib/model/exercises/random_exercise.dart
+++ b/lib/model/exercises/random_exercise.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:sayilar/model/exercises/exercise.dart';
 import 'package:sayilar/model/questions/question.dart';
 
@@ -14,8 +16,11 @@ class RandomExercise extends Exercise<Question> {
   /// All the available exercises for selecting [Question]s from.
   final List<Exercise> exercises;
 
+  /// A random number generator for selecting a random exercise.
+  static final Random _random = Random();
+
   @override
   Question nextQuestion() {
-    return (List.from(exercises)..shuffle()).first.nextQuestion();
+    return exercises[_random.nextInt(exercises.length)].nextQuestion();
   }
 }

--- a/lib/model/questions/calculate_question.dart
+++ b/lib/model/questions/calculate_question.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:sayilar/extensions/written_out.dart';
 import 'package:sayilar/model/questions/question.dart';
 
@@ -18,11 +20,14 @@ enum Operation {
   /// The textual sign representing this mathematical operation.
   final String operation;
 
+  /// A random number generator for selecting a random variant.
+  static final Random _random = Random();
+
   @override
   String toString() => operation;
 
   /// Returns one random mathematical operation from all of the possible ones.
-  static Operation get random => (List.from(values)..shuffle()).first;
+  static Operation get random => values[_random.nextInt(values.length)];
 
   /// Returns the result of applying this mathematical operation to two numbers.
   int apply(int a, int b) {


### PR DESCRIPTION
Improve the random selection of

- an `Operation` in `Operation.random`
- an `Exercise` in `RandomExercise.nextQuestion()`

by not shuffling an entire list of options, but rather using `Random.nextInt()` to select a random item out of that list of options.

As shuffling internally does `N = length` times `Random.nextInt()` calls to randomly position each element, it is computationally less expensive to do just a single (`N = 1`) `Random.nextInt()` call to select a single random item.