### PR TITLE
Use keyboards suitable for questions

### DIFF
--- a/lib/model/questions/question.dart
+++ b/lib/model/questions/question.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 import 'package:sayilar/extensions/normalize.dart';
 
 /// An abstract base class for textual questions to be asked the user.
@@ -13,6 +15,14 @@ abstract class Question {
 
   /// A list of formatted strings of alternate answers the user can put in too.
   List<String> get alternateAnswers => [];
+
+  /// The [TextInputType] suitable for inputting answers to `this` question.
+  ///
+  /// Implementing classes can override this to request more specialised
+  /// keyboards for inputting answers (e.g. [TextInputType.number] for number
+  /// related questions). If left `null`, the system's standard keyboard will be
+  /// used.
+  TextInputType? get keyboardType => null;
 
   /// Return whether an [answer] given in response to this question is correct.
   ///

--- a/lib/model/questions/recognize_question.dart
+++ b/lib/model/questions/recognize_question.dart
@@ -1,3 +1,7 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
 import 'package:sayilar/extensions/written_out.dart';
 import 'package:sayilar/model/questions/question.dart';
 
@@ -21,4 +25,14 @@ class RecognizeQuestion extends Question {
 
   @override
   String get answer => number.toString();
+
+  @override
+  TextInputType get keyboardType => TextInputType.numberWithOptions(
+        // FIXME: As iOS does not support a "Done" button on its numpad
+        // keyboard, this is a workaround to open the normal keyboard starting
+        // in the numbers tab, as it has a "Done" button, which is deemed more
+        // important for a good user experience than having the more specialised
+        // numpad keyboard.
+        signed: Platform.isIOS,
+      );
 }

--- a/lib/model/questions/recognize_time_question.dart
+++ b/lib/model/questions/recognize_time_question.dart
@@ -26,4 +26,7 @@ class RecognizeTimeQuestion extends Question {
 
   @override
   List<String> get alternateAnswers => time.asAlternateStrings;
+
+  @override
+  TextInputType get keyboardType => TextInputType.datetime;
 }

--- a/lib/widgets/topics/exercise_topic_body.dart
+++ b/lib/widgets/topics/exercise_topic_body.dart
@@ -57,6 +57,7 @@ class _ExerciseTopicBodyState
           TextField(
             enabled: inputEnabled,
             controller: inputController,
+            keyboardType: currentQuestion.keyboardType,
             onSubmitted: (answer) => checkAnswer(
               answer,
               // Clear the input text field for the next question.


### PR DESCRIPTION
Show specialised keyboards that are suitable for putting in answers to each `Question` type, e.g. show a numpad for `Question`s where the user has to input numbers.

As this is set for each `Question`, this also works for `Exercise`s, where the `Question` type changes (e.g. `RandomExercise`).

This fixes #32.